### PR TITLE
chore: export access control interface

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,6 +1,6 @@
 mod access_control;
 
-use access_control::access_control_component;
+use access_control::{access_control_component, IAccessControlDispatcher, IAccessControlDispatcherTrait};
 #[cfg(test)]
 mod tests {
     mod mock_access_control;


### PR DESCRIPTION
This PR exports `IAccessControlDispatcher` and `IAccessControlDispatcherTrait` for less verbose imports.