### PR TITLE
chore: bump dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.4.0"
+          scarb-version: "2.6.3"
       - run: scarb fmt --check
       - run: scarb build
 
       - uses: foundry-rs/setup-snfoundry@v2
         with:
-          starknet-foundry-version: "0.13.1"
+          starknet-foundry-version: "0.19.0"
       - run: snforge test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,7 @@ jobs:
       - run: scarb fmt --check
       - run: scarb build
 
-      - name: Install Universal-Sierra-Compiler
-        run: curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh -s -- v2.0.0
-
-      - uses: foundry-rs/setup-snfoundry@v2
+      - uses: foundry-rs/setup-snfoundry@v3
         with:
           starknet-foundry-version: "0.19.0"
       - run: snforge test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
       - run: scarb fmt --check
       - run: scarb build
 
+      - name: Install Universal-Sierra-Compiler
+        run: curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh -s -- v2.0.0
+
       - uses: foundry-rs/setup-snfoundry@v2
         with:
           starknet-foundry-version: "0.19.0"

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,12 +3,12 @@ version = 1
 
 [[package]]
 name = "access_control"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "snforge_std",
 ]
 
 [[package]]
 name = "snforge_std"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.13.1#e1412ed040d10e66be0fd84115f72a667b57a116"
+version = "0.19.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.19.0#a3391dce5bdda51c63237032e6cfc64fb7a346d4"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "access_control"
 version = "0.3.0"
-cairo-version = "2.6.3"
+cairo-version = "2.6.0"
 authors = ["Lindy Labs"]
 description = "Member-based access control component for Cairo"
 readme = "README.md"
@@ -10,7 +10,7 @@ license-file = "LICENSE"
 keywords = ["access control", "authorization", "cairo", "starknet"]
 
 [dependencies]
-starknet = "2.6.3"
+starknet >= "2.6.0"
 
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.19.0" }

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -10,7 +10,7 @@ license-file = "LICENSE"
 keywords = ["access control", "authorization", "cairo", "starknet"]
 
 [dependencies]
-starknet >= "2.6.0"
+starknet = ">= 2.6.0"
 
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.19.0" }

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "access_control"
-version = "0.2.0"
-cairo-version = "2.4.0"
+version = "0.3.0"
+cairo-version = "2.6.3"
 authors = ["Lindy Labs"]
 description = "Member-based access control component for Cairo"
 readme = "README.md"
@@ -10,8 +10,10 @@ license-file = "LICENSE"
 keywords = ["access control", "authorization", "cairo", "starknet"]
 
 [dependencies]
-starknet = "2.4.0"
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.13.1" }
+starknet = "2.6.3"
+
+[dev-dependencies]
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.19.0" }
 
 [lib]
 

--- a/src/tests/test_access_control.cairo
+++ b/src/tests/test_access_control.cairo
@@ -5,7 +5,6 @@ mod test_access_control {
     use snforge_std::cheatcodes::events::EventAssertions;
     use snforge_std::{
         spy_events, SpyOn, EventSpy, EventFetcher, event_name_hash, Event, start_prank, CheatTarget, test_address,
-        PrintTrait
     };
     use starknet::contract_address::{ContractAddress, ContractAddressZeroable, contract_address_try_from_felt252};
     //
@@ -80,14 +79,6 @@ mod test_access_control {
 
         assert(state.get_admin() == admin, 'initialize wrong admin');
 
-        let expected_events = array![
-            (
-                test_address(),
-                access_control_component::Event::AdminChanged(
-                    access_control_component::AdminChanged { old_admin: zero_addr(), new_admin: admin(), }
-                )
-            ),
-        ];
         spy.fetch_events();
 
         let (_, event) = spy.events.at(0);


### PR DESCRIPTION
This PR bumps Cairo and related dependencies to `v2.6.3`.