### PR TITLE
chore: bump dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.6.3"
+          scarb-version: "2.7.0"
       - run: scarb fmt --check
       - run: scarb build
 
       - uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: "0.19.0"
+          starknet-foundry-version: "0.27.0"
       - run: snforge test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "2.7.0"
       - run: scarb fmt --check
       - run: scarb build
 
       - uses: foundry-rs/setup-snfoundry@v3
-        with:
-          starknet-foundry-version: "0.27.0"
       - run: snforge test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+scarb 2.7.0
+starknet-foundry 0.27.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,12 +3,12 @@ version = 1
 
 [[package]]
 name = "access_control"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "snforge_std",
 ]
 
 [[package]]
 name = "snforge_std"
-version = "0.19.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.19.0#a3391dce5bdda51c63237032e6cfc64fb7a346d4"
+version = "0.27.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.27.0#2d99b7c00678ef0363881ee0273550c44a9263de"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,6 +2,7 @@
 name = "access_control"
 version = "0.4.0"
 cairo-version = "2.7.0"
+edition = "2024_07"
 authors = ["Lindy Labs"]
 description = "Member-based access control component for Cairo"
 readme = "README.md"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "access_control"
-version = "0.3.0"
-cairo-version = "2.6.0"
+version = "0.4.0"
+cairo-version = "2.7.0"
 authors = ["Lindy Labs"]
 description = "Member-based access control component for Cairo"
 readme = "README.md"
@@ -10,10 +10,10 @@ license-file = "LICENSE"
 keywords = ["access control", "authorization", "cairo", "starknet"]
 
 [dependencies]
-starknet = ">= 2.6.0"
+starknet = ">= 2.7.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.19.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.27.0" }
 
 [lib]
 

--- a/src/access_control.cairo
+++ b/src/access_control.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 
 #[starknet::interface]
-trait IAccessControl<TContractState> {
+pub trait IAccessControl<TContractState> {
     fn get_roles(self: @TContractState, account: ContractAddress) -> u128;
     fn has_role(self: @TContractState, role: u128, account: ContractAddress) -> bool;
     fn get_admin(self: @TContractState) -> ContractAddress;
@@ -14,13 +14,15 @@ trait IAccessControl<TContractState> {
 }
 
 #[starknet::component]
-mod access_control_component {
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::storage::Map;
+pub mod access_control_component {
+    use core::num::traits::Zero;
+    use starknet::storage::{
+        StoragePointerReadAccess, StoragePointerWriteAccess, StorageMapReadAccess, StorageMapWriteAccess, Map
+    };
     use starknet::{ContractAddress, get_caller_address};
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         admin: ContractAddress,
         pending_admin: ContractAddress,
         roles: Map::<ContractAddress, u128>
@@ -28,7 +30,7 @@ mod access_control_component {
 
     #[event]
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    enum Event {
+    pub enum Event {
         AdminChanged: AdminChanged,
         NewPendingAdmin: NewPendingAdmin,
         RoleGranted: RoleGranted,
@@ -36,30 +38,30 @@ mod access_control_component {
     }
 
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    struct AdminChanged {
+    pub struct AdminChanged {
         old_admin: ContractAddress,
         new_admin: ContractAddress
     }
 
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    struct NewPendingAdmin {
+    pub struct NewPendingAdmin {
         new_admin: ContractAddress
     }
 
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    struct RoleGranted {
+    pub struct RoleGranted {
         user: ContractAddress,
         role_granted: u128
     }
 
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    struct RoleRevoked {
+    pub struct RoleRevoked {
         user: ContractAddress,
         role_revoked: u128
     }
 
     #[embeddable_as(AccessControl)]
-    impl AccessControlPublic<
+    pub impl AccessControlPublic<
         TContractState, +HasComponent<TContractState>
     > of super::IAccessControl<ComponentState<TContractState>> {
         //
@@ -118,12 +120,12 @@ mod access_control_component {
             assert(self.get_pending_admin() == caller, 'Caller not pending admin');
             self.set_admin_helper(caller);
 
-            self.pending_admin.write(ContractAddressZeroable::zero());
+            self.pending_admin.write(Zero::zero());
         }
     }
 
     #[generate_trait]
-    impl AccessControlHelpers<
+    pub impl AccessControlHelpers<
         TContractState, +HasComponent<TContractState>
     > of AccessControlHelpersTrait<TContractState> {
         fn initializer(ref self: ComponentState<TContractState>, admin: ContractAddress, roles: Option<u128>) {

--- a/src/access_control.cairo
+++ b/src/access_control.cairo
@@ -16,13 +16,14 @@ trait IAccessControl<TContractState> {
 #[starknet::component]
 mod access_control_component {
     use starknet::contract_address::ContractAddressZeroable;
+    use starknet::storage::Map;
     use starknet::{ContractAddress, get_caller_address};
 
     #[storage]
     struct Storage {
         admin: ContractAddress,
         pending_admin: ContractAddress,
-        roles: LegacyMap::<ContractAddress, u128>
+        roles: Map::<ContractAddress, u128>
     }
 
     #[event]

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,6 +1,6 @@
-pub mod access_control;
+mod access_control;
 
-use access_control::{access_control_component, IAccessControlDispatcher, IAccessControlDispatcherTrait};
+pub use access_control::{access_control_component, IAccessControlDispatcher, IAccessControlDispatcherTrait};
 #[cfg(test)]
 mod tests {
     mod mock_access_control;

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,4 +1,4 @@
-mod access_control;
+pub mod access_control;
 
 use access_control::{access_control_component, IAccessControlDispatcher, IAccessControlDispatcherTrait};
 #[cfg(test)]

--- a/src/tests/mock_access_control.cairo
+++ b/src/tests/mock_access_control.cairo
@@ -1,5 +1,5 @@
 #[starknet::contract]
-mod mock_access_control {
+pub mod mock_access_control {
     use access_control::access_control_component;
     use starknet::ContractAddress;
 
@@ -12,7 +12,7 @@ mod mock_access_control {
     #[storage]
     struct Storage {
         #[substorage(v0)]
-        access_control: access_control_component::Storage
+        pub access_control: access_control_component::Storage
     }
 
     #[event]

--- a/src/tests/test_access_control.cairo
+++ b/src/tests/test_access_control.cairo
@@ -2,10 +2,7 @@ mod test_access_control {
     use access_control::access_control_component::{AccessControlPublic, AccessControlHelpers};
     use access_control::access_control_component;
     use access_control::tests::mock_access_control::mock_access_control;
-    use snforge_std::cheatcodes::events::EventAssertions;
-    use snforge_std::{
-        spy_events, SpyOn, EventSpy, EventFetcher, event_name_hash, Event, start_prank, CheatTarget, test_address,
-    };
+    use snforge_std::{spy_events, EventSpy, Event, EventSpyTrait, start_cheat_caller_address, test_address};
     use starknet::contract_address::{ContractAddress, ContractAddressZeroable, contract_address_try_from_felt252};
     //
     // Constants
@@ -47,7 +44,7 @@ mod test_access_control {
         let mut state = state();
         state.access_control.initializer(admin(), Option::None);
 
-        start_prank(CheatTarget::All, caller);
+        start_cheat_caller_address(test_address(), caller);
 
         state
     }
@@ -55,7 +52,7 @@ mod test_access_control {
     fn set_pending_admin(
         ref state: mock_access_control::ContractState, caller: ContractAddress, pending_admin: ContractAddress
     ) {
-        start_prank(CheatTarget::All, caller);
+        start_cheat_caller_address(test_address(), caller);
         state.set_pending_admin(pending_admin);
     }
 
@@ -71,7 +68,7 @@ mod test_access_control {
 
     #[test]
     fn test_initializer() {
-        let mut spy = spy_events(SpyOn::One(test_address()));
+        let mut spy = spy_events();
 
         let admin = admin();
 
@@ -79,12 +76,12 @@ mod test_access_control {
 
         assert(state.get_admin() == admin, 'initialize wrong admin');
 
-        spy.fetch_events();
+        let events = spy.get_events();
 
-        let (_, event) = spy.events.at(0);
+        let (_, event) = events.events.at(0);
 
-        assert_eq!(spy.events.len(), 1, "wrong number of events");
-        assert_eq!(*event.keys[1], event_name_hash('AdminChanged'), "wrong event name");
+        assert_eq!(events.events.len(), 1, "wrong number of events");
+        assert_eq!(event.keys[1], @selector!("AdminChanged"), "wrong event name");
         assert_eq!(*event.data[0], 0, "should be zero address");
         assert_eq!(*event.data[1], ADMIN_ADDR, "should be admin adddress");
     }
@@ -93,7 +90,7 @@ mod test_access_control {
     fn test_grant_role() {
         let mut state = setup(admin());
 
-        let mut spy = spy_events(SpyOn::One(test_address()));
+        let mut spy = spy_events();
 
         default_grant(ref state);
 
@@ -102,17 +99,17 @@ mod test_access_control {
         assert(state.has_role(R2, u), 'role R2 not granted');
         assert_eq!(state.get_roles(u), R1 + R2, "not all roles granted");
 
-        spy.fetch_events();
+        let events = spy.get_events();
 
-        assert_eq!(spy.events.len(), 2, "wrong number of events");
+        assert_eq!(events.events.len(), 2, "wrong number of events");
 
-        let (_, event) = spy.events.at(0);
-        assert_eq!(*event.keys[1], event_name_hash('RoleGranted'), "wrong event name");
+        let (_, event) = events.events.at(0);
+        assert_eq!(event.keys[1], @selector!("RoleGranted"), "wrong event name");
         assert_eq!(*event.data[0], u.into(), "wrong user in event #1");
         assert_eq!(*event.data[1], R1.into(), "wrong role in event #1");
 
-        let (_, event) = spy.events.at(1);
-        assert_eq!(*event.keys[1], event_name_hash('RoleGranted'), "wrong event name");
+        let (_, event) = events.events.at(1);
+        assert_eq!(event.keys[1], @selector!("RoleGranted"), "wrong event name");
         assert_eq!(*event.data[0], u.into(), "wrong user in event #2");
         assert_eq!(*event.data[1], R2.into(), "wrong role in event #2");
     }
@@ -141,7 +138,7 @@ mod test_access_control {
         let mut state = setup(admin());
         default_grant(ref state);
 
-        let mut spy = spy_events(SpyOn::One(test_address()));
+        let mut spy = spy_events();
 
         let u = user();
         state.revoke_role(R1, u);
@@ -149,12 +146,12 @@ mod test_access_control {
         assert(state.has_role(R2, u), 'role R2 not kept');
         assert_eq!(state.get_roles(u), R2, "incorrect roles");
 
-        spy.fetch_events();
+        let events = spy.get_events();
 
-        assert_eq!(spy.events.len(), 1, "wrong number of events");
+        assert_eq!(events.events.len(), 1, "wrong number of events");
 
-        let (_, event) = spy.events.at(0);
-        assert_eq!(*event.keys[1], event_name_hash('RoleRevoked'), "wrong event name");
+        let (_, event) = events.events.at(0);
+        assert_eq!(event.keys[1], @selector!("RoleRevoked"), "wrong event name");
         assert_eq!(*event.data[0], u.into(), "wrong user in event");
         assert_eq!(*event.data[1], R1.into(), "wrong role in event");
     }
@@ -163,7 +160,7 @@ mod test_access_control {
     #[should_panic(expected: ('Caller not admin',))]
     fn test_revoke_role_not_admin() {
         let mut state = setup(admin());
-        start_prank(CheatTarget::All, badguy());
+        start_cheat_caller_address(test_address(), badguy());
         state.revoke_role(R1, user());
     }
 
@@ -172,10 +169,10 @@ mod test_access_control {
         let mut state = setup(admin());
         default_grant(ref state);
 
-        let mut spy = spy_events(SpyOn::One(test_address()));
+        let mut spy = spy_events();
 
         let u = user();
-        start_prank(CheatTarget::All, u);
+        start_cheat_caller_address(test_address(), u);
         state.renounce_role(R1);
         assert(!state.has_role(R1, u), 'R1 role kept');
 
@@ -183,17 +180,17 @@ mod test_access_control {
         let non_existent_role: u128 = 64;
         state.renounce_role(non_existent_role);
 
-        spy.fetch_events();
+        let events = spy.get_events();
 
-        assert_eq!(spy.events.len(), 2, "wrong number of events");
+        assert_eq!(events.events.len(), 2, "wrong number of events");
 
-        let (_, event) = spy.events.at(0);
-        assert_eq!(*event.keys[1], event_name_hash('RoleRevoked'), "wrong event name");
+        let (_, event) = events.events.at(0);
+        assert_eq!(event.keys[1], @selector!("RoleRevoked"), "wrong event name");
         assert_eq!(*event.data[0], u.into(), "wrong user in event #1");
         assert_eq!(*event.data[1], R1.into(), "wrong role in event #1");
 
-        let (_, event) = spy.events.at(1);
-        assert_eq!(*event.keys[1], event_name_hash('RoleRevoked'), "wrong event name");
+        let (_, event) = events.events.at(1);
+        assert_eq!(event.keys[1], @selector!("RoleRevoked"), "wrong event name");
         assert_eq!(*event.data[0], u.into(), "wrong user in event #2");
         assert_eq!(*event.data[1], non_existent_role.into(), "wrong role in event #2");
     }
@@ -202,18 +199,18 @@ mod test_access_control {
     fn test_set_pending_admin() {
         let mut state = setup(admin());
 
-        let mut spy = spy_events(SpyOn::One(test_address()));
+        let mut spy = spy_events();
 
         let pending_admin = user();
         state.set_pending_admin(pending_admin);
         assert(state.get_pending_admin() == pending_admin, 'pending admin not changed');
 
-        spy.fetch_events();
+        let events = spy.get_events();
 
-        assert_eq!(spy.events.len(), 1, "wrong number of events");
+        assert_eq!(events.events.len(), 1, "wrong number of events");
 
-        let (_, event) = spy.events.at(0);
-        assert_eq!(*event.keys[1], event_name_hash('NewPendingAdmin'), "wrong event name");
+        let (_, event) = events.events.at(0);
+        assert_eq!(event.keys[1], @selector!("NewPendingAdmin"), "wrong event name");
         assert_eq!(*event.data[0], pending_admin.into(), "wrong user in event");
     }
 
@@ -221,7 +218,7 @@ mod test_access_control {
     #[should_panic(expected: ('Caller not admin',))]
     fn test_set_pending_admin_not_admin() {
         let mut state = setup(admin());
-        start_prank(CheatTarget::All, badguy());
+        start_cheat_caller_address(test_address(), badguy());
         state.set_pending_admin(badguy());
     }
 
@@ -233,20 +230,20 @@ mod test_access_control {
         let pending_admin = user();
         set_pending_admin(ref state, current_admin, pending_admin);
 
-        let mut spy = spy_events(SpyOn::One(test_address()));
+        let mut spy = spy_events();
 
-        start_prank(CheatTarget::All, pending_admin);
+        start_cheat_caller_address(test_address(), pending_admin);
         state.accept_admin();
 
         assert(state.get_admin() == pending_admin, 'admin not changed');
         assert(state.get_pending_admin().is_zero(), 'pending admin not reset');
 
-        spy.fetch_events();
+        let events = spy.get_events();
 
-        assert_eq!(spy.events.len(), 1, "wrong number of events");
+        assert_eq!(events.events.len(), 1, "wrong number of events");
 
-        let (_, event) = spy.events.at(0);
-        assert_eq!(*event.keys[1], event_name_hash('AdminChanged'), "wrong event name");
+        let (_, event) = events.events.at(0);
+        assert_eq!(event.keys[1], @selector!("AdminChanged"), "wrong event name");
         assert_eq!(*event.data[0], current_admin.into(), "wrong old admin in event");
         assert_eq!(*event.data[1], pending_admin.into(), "wrong new admin in event");
     }
@@ -260,7 +257,7 @@ mod test_access_control {
         let pending_admin = user();
         set_pending_admin(ref state, current_admin, pending_admin);
 
-        start_prank(CheatTarget::All, badguy());
+        start_cheat_caller_address(test_address(), badguy());
         state.accept_admin();
     }
 
@@ -269,7 +266,7 @@ mod test_access_control {
         let mut state = setup(admin());
         default_grant(ref state);
 
-        start_prank(CheatTarget::All, user());
+        start_cheat_caller_address(test_address(), user());
         // should not throw
         state.access_control.assert_has_role(R1);
         state.access_control.assert_has_role(R1 + R2);
@@ -281,7 +278,7 @@ mod test_access_control {
         let mut state = setup(admin());
         default_grant(ref state);
 
-        start_prank(CheatTarget::All, user());
+        start_cheat_caller_address(test_address(), user());
         state.access_control.assert_has_role(R3);
     }
 }

--- a/src/tests/test_access_control.cairo
+++ b/src/tests/test_access_control.cairo
@@ -2,8 +2,9 @@ mod test_access_control {
     use access_control::access_control_component::{AccessControlPublic, AccessControlHelpers};
     use access_control::access_control_component;
     use access_control::tests::mock_access_control::mock_access_control;
+    use core::num::traits::Zero;
     use snforge_std::{spy_events, EventSpy, Event, EventSpyTrait, start_cheat_caller_address, test_address};
-    use starknet::contract_address::{ContractAddress, ContractAddressZeroable, contract_address_try_from_felt252};
+    use starknet::ContractAddress;
     //
     // Constants
     //
@@ -17,19 +18,19 @@ mod test_access_control {
     const ADMIN_ADDR: felt252 = 'access control admin';
 
     fn admin() -> ContractAddress {
-        contract_address_try_from_felt252(ADMIN_ADDR).unwrap()
+        ADMIN_ADDR.try_into().unwrap()
     }
 
     fn badguy() -> ContractAddress {
-        contract_address_try_from_felt252('bad guy').unwrap()
+        'bad guy'.try_into().unwrap()
     }
 
     fn user() -> ContractAddress {
-        contract_address_try_from_felt252('user').unwrap()
+        'user'.try_into().unwrap()
     }
 
     fn zero_addr() -> ContractAddress {
-        ContractAddressZeroable::zero()
+        Zero::zero()
     }
 
     //
@@ -127,7 +128,7 @@ mod test_access_control {
         default_grant(ref state);
 
         let u = user();
-        let u2 = contract_address_try_from_felt252('user 2').unwrap();
+        let u2 = 'user 2'.try_into().unwrap();
         state.grant_role(R2 + R3 + R4, u2);
         assert_eq!(state.get_roles(u), R1 + R2, "wrong roles for u");
         assert_eq!(state.get_roles(u2), R2 + R3 + R4, "wrong roles for u2");


### PR DESCRIPTION
This PR bumps Cairo to `v2.7.0`. It also bumps the package's version to `0.4.0`.